### PR TITLE
fix: retire btn is shown on open leaderboard popup

### DIFF
--- a/app/src/pages/Game/components/popup/PopupLeaderboard.js
+++ b/app/src/pages/Game/components/popup/PopupLeaderboard.js
@@ -299,7 +299,7 @@ class PopupLeaderboard extends Popup {
     this.gameEndTime.setVisible(!this.isEnded);
     this.endTimeExtension.setVisible(!this.isEnded);
     this.buttonBack.setVisible(!this.isEnded);
-    this.buttonRetire.setVisible(!this.isEnded);
+    this.buttonRetire.setVisible(!this.isEnded && this.modeSwitch.mode === 'Reputation');
     if (this.isEnded) {
       if (!this.isSimulator) {
         this.remove(this.buttonBack);


### PR DESCRIPTION
![image](https://github.com/wearedayone/casino-tycoon/assets/59161372/911443d3-53e5-400c-9180-df3a54a0d52c)
