### PR TITLE
fix: user gets blocked by install modal on mobile

### DIFF
--- a/app/src/components/InstallGuideModal.js
+++ b/app/src/components/InstallGuideModal.js
@@ -21,7 +21,7 @@ const InstallGuideModal = () => {
     }
   }, []);
 
-  const open = pathname !== '/deposit' && deviceInfo.displayMode === 'browser';
+  const open = !pathname.startsWith('/deposit') && deviceInfo.displayMode === 'browser';
 
   const skip = () => {
     setDeviceInfo({ os: null, displayMode: null });


### PR DESCRIPTION
<img width="480" alt="Screen Shot 2024-03-08 at 16 42 51" src="https://github.com/wearedayone/casino-tycoon/assets/59161372/ddf5ba58-084e-4d40-bb57-a47ffc42c77c">

user cannot deposit because when path is '/deposit/user' then InstallGuideModal is enabled, blocking the UI